### PR TITLE
Add dbt version check and adapt dbt test module for upcoming deprecation

### DIFF
--- a/droughty/droughty/droughty_dbt/dbt_test_module.py
+++ b/droughty/droughty/droughty_dbt/dbt_test_module.py
@@ -25,6 +25,15 @@ import ruamel.yaml
 import git
 
 
+def get_test_definition_key():
+    """
+    Returns the appropriate test definition key based on the dbt version.
+    """
+    if is_version_gte_1_8():
+        return "data_tests"
+    else:
+        return "tests"
+
 def get_all_values(nested_dictionary):
 
     test_overwrite = ExploresVariables.test_overwrite

--- a/droughty/droughty/droughty_dbt/dbt_test_module.py
+++ b/droughty/droughty/droughty_dbt/dbt_test_module.py
@@ -18,6 +18,7 @@ from droughty.droughty_core.config import (
     IdentifyConfigVariables,
     ExploresVariables
 )
+from droughty.droughty_dbt.dbt_version_util import is_version_gte_1_8
 
 import sys
 import ruamel.yaml

--- a/droughty/droughty/droughty_dbt/dbt_test_module.py
+++ b/droughty/droughty/droughty_dbt/dbt_test_module.py
@@ -35,6 +35,8 @@ def get_test_definition_key():
         return "tests"
 
 def get_all_values(nested_dictionary):
+    
+    tests_config_key = get_test_definition_key()
 
     test_overwrite = ExploresVariables.test_overwrite
 
@@ -73,22 +75,22 @@ def get_all_values(nested_dictionary):
 
                         if "pk" in key1 and "not_null" not in value1 and "unique" not in value1:
                             
-                            elem = {"name": key1, "description": "{{doc("+'"'+key1+'"'+")}}", "tests": ["not_null","unique"]}
+                            elem = {"name": key1, "description": "{{doc("+'"'+key1+'"'+")}}", tests_config_key: ["not_null","unique"]}
                             seq.append(elem)
                             
                         elif "fk" in key1:
                             
-                            elem = {"name": key1, "description": "{{doc("+'"'+key1+'"'+")}}", "tests": ["dbt_utils.at_least_one"]}
+                            elem = {"name": key1, "description": "{{doc("+'"'+key1+'"'+")}}", tests_config_key: ["dbt_utils.at_least_one"]}
                             seq.append(elem)   
                             
                         elif "valid_to" in key1 or "valid_from" in key1:
                             
-                            elem = {"name": key1, "description": "{{doc("+'"'+key1+'"'+")}}", "tests": ["dbt_utils.expression_is_true"":""expression"":"" valid_from < valid_to","not_null","unique"]}
+                            elem = {"name": key1, "description": "{{doc("+'"'+key1+'"'+")}}", tests_config_key: ["dbt_utils.expression_is_true"":""expression"":"" valid_from < valid_to","not_null","unique"]}
                             seq.append(elem)  
 
                         elif "pk" not in key1 or "fk" not in key1:
                     
-                            elem = {"name": key1, "description": "{{doc("+'"'+key1+'"'+")}}", "tests": [""+"dbt_utils.at_least_one"]}
+                            elem = {"name": key1, "description": "{{doc("+'"'+key1+'"'+")}}", tests_config_key: [""+"dbt_utils.at_least_one"]}
                             seq.append(elem)  
 
                         elif "pk" not in key1 or "fk" not in key1:
@@ -100,22 +102,22 @@ def get_all_values(nested_dictionary):
 
                             if "pk" in key1:
                                 
-                                elem = {"name": key1, "tests": ["not_null","unique"]}
+                                elem = {"name": key1, tests_config_key: ["not_null","unique"]}
                                 seq.append(elem)
                                 
                             elif "fk" in key1:
                                 
-                                elem = {"name": key1, "tests": ["dbt_utils.at_least_one"]}
+                                elem = {"name": key1, tests_config_key: ["dbt_utils.at_least_one"]}
                                 seq.append(elem)   
                                 
                             elif "valid_to" in key1 or "valid_from" in key1:
                                 
-                                elem = {"name": key1, "tests": ["dbt_utils.expression_is_true"":""expression"":"" valid_from < valid_to","not_null","unique"]}
+                                elem = {"name": key1, tests_config_key: ["dbt_utils.expression_is_true"":""expression"":"" valid_from < valid_to","not_null","unique"]}
                                 seq.append(elem)  
 
                             elif "pk" not in key1 or "fk" not in key1:
                         
-                                elem = {"name": key1, "tests": [""+"dbt_utils.at_least_one"]}
+                                elem = {"name": key1, tests_config_key: [""+"dbt_utils.at_least_one"]}
                                 seq.append(elem)
                     
                 elif key + "-" + key1 in ignore_test_keys_and_values and key not in ExploresVariables.test_ignore:
@@ -123,12 +125,12 @@ def get_all_values(nested_dictionary):
                     if key1 in described_columns_list:
 
                             
-                        elem = {"name": key1, "description": "{{doc("+'"'+key1+'"'+")}}", "tests": value1}
+                        elem = {"name": key1, "description": "{{doc("+'"'+key1+'"'+")}}", tests_config_key: value1}
                         seq.append(elem)
 
                     elif key1 not in described_columns_list:
 
-                        elem = {"name": key1, "tests": value1}
+                        elem = {"name": key1, tests_config_key: value1}
                         seq.append(elem)
             
             res.append([{"name": key, "columns": seq}])

--- a/droughty/droughty/droughty_dbt/dbt_version_util.py
+++ b/droughty/droughty/droughty_dbt/dbt_version_util.py
@@ -1,0 +1,9 @@
+import dbt.version
+
+def is_version_gte_1_8():
+    """
+    Checks if the installed dbt version is greater than or equal to 1.8.0.
+    """
+    installed_version = dbt.version.get_installed_version()
+    target_version = dbt.semver.VersionSpecifier.from_version_string("1.8.0")
+    return installed_version.compare(target_version) >= 0

--- a/droughty/droughty/droughty_dbt/dbt_version_util.py
+++ b/droughty/droughty/droughty_dbt/dbt_version_util.py
@@ -1,9 +1,10 @@
 import dbt.version
+import dbt_common.semver as semver
 
 def is_version_gte_1_8():
     """
     Checks if the installed dbt version is greater than or equal to 1.8.0.
     """
     installed_version = dbt.version.get_installed_version()
-    target_version = dbt.semver.VersionSpecifier.from_version_string("1.8.0")
+    target_version = semver.VersionSpecifier.from_version_string("1.8.0")
     return installed_version.compare(target_version) >= 0


### PR DESCRIPTION
### Summary
This pull request adds a feature to check the installed dbt version and adapt test definitions accordingly. Specifically, it prepares for the announced deprecation where dbt will use `data_tests:` instead of `tests:` for test definitions in configuration files.

### Changes
- Added a `dbt_version_util.py` module with a function `is_version_gte_1_8` to check the dbt version.
- Modified `dbt_test_module.py` to use the new version check function and adapt test definitions based on the installed dbt version.

### Motivation
See Issue #79 for details.

### Testing
Tested locally with dbt versions to ensure correct behavior:
- When running with dbt 1.7.x, `droughty_schema.yml` uses `"tests:"
- When running with dbt 1.8.1, `droughty_schema.yml` uses `"data_tests:"

### Related Issues
Closes #79 